### PR TITLE
Adding Coverage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -213,9 +213,9 @@ checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
 
 [[package]]
 name = "libc"
-version = "0.2.142"
+version = "0.2.144"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a987beff54b60ffa6d51982e1aa1146bc42f19bd26be28b0586f252fccf5317"
+checksum = "2b00cc1c228a6782d0f076e7b232802e0c5689d41bb5df366f2a6b6621cfdfe1"
 
 [[package]]
 name = "linux-raw-sys"
@@ -261,9 +261,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.26"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
+checksum = "8f4f29d145265ec1c483c7c654450edde0bfe043d3938d6972630663356d9500"
 dependencies = [
  "proc-macro2",
 ]
@@ -320,9 +320,9 @@ checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
 
 [[package]]
 name = "serde"
-version = "1.0.160"
+version = "1.0.163"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb2f3770c8bce3bcda7e149193a069a0f4365bda1fa5cd88e03bca26afc1216c"
+checksum = "2113ab51b87a539ae008b5c6c02dc020ffa39afd2d83cffcb3f4eb2722cebec2"
 
 [[package]]
 name = "strsim"

--- a/src/flipper/app_state.rs
+++ b/src/flipper/app_state.rs
@@ -1,19 +1,29 @@
 use std::collections::BTreeMap;
 use std::fmt;
 
-// information about the current random generation
+/// information about the current random generation
 pub struct AppState {
-    pub last_result: bool,               // last roll
-    pub current_result: bool,            // current roll
-    pub current_run: u32,                // current streak of the same result
-    pub longest_run: u32,                // largest streak of the same result
-    pub run_lengths: BTreeMap<u32, u32>, // <length, times_occurred>
-    pub count_result_in_a_run: u32,      // how many results were in runs
-    pub total_count: u32,                // total number of rolls
-    pub current_id: u32,                 // the current run index x of `total_count`
+    /// last roll
+    pub last_result: bool,
+    /// current roll
+    pub current_result: bool,
+    /// current streak of the same result
+    pub current_run: u32,
+    /// largest streak of the same result
+    pub longest_run: u32,
+    /// <length, times_occurred>
+    pub run_lengths: BTreeMap<u32, u32>,
+    /// how many results were in runs
+    pub count_result_in_a_run: u32,
+    /// total number of rolls
+    pub total_count: u32,
+    /// the current run index x of `total_count`
+    pub current_id: u32,
 }
 
 impl AppState {
+    /// create a new state
+    /// total_count: the intended number of state changes
     pub fn new(total_count: u32) -> AppState {
         AppState {
             last_result: false,
@@ -27,6 +37,7 @@ impl AppState {
         }
     }
 
+    /// moves self into a new state, calculating the internal sequence length values
     pub fn next(mut self, result: bool) -> AppState {
         let last_result = self.current_result;
         let is_run = last_result == result;
@@ -51,6 +62,10 @@ impl AppState {
     }
 }
 
+/// formats the AppState to return for example:
+/// > total rolls: 10
+/// > total runs: 7, (0.7%)
+/// > longest run: 4
 impl fmt::Display for AppState {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         writeln!(f, "total rolls: {}", self.total_count)?;
@@ -146,11 +161,77 @@ mod tests {
     }
 
     #[test]
+    fn next_saved_context() {
+        // GIVEN a list of boolean values
+        let list = [
+            true, false, false, false, true, false, true, true, true, true, true, false, false,
+            false, false, false, false, false, false, true, true, false, true, false,
+        ];
+
+        let mut state = AppState::new(list.len() as u32);
+
+        // WHEN the next() function is called on that list
+        for b in list {
+            state = state.next(b);
+        }
+
+        // THEN the expected result should be whatever it was when I programmed it
+
+        // programmatically determining these values
+        let max_sequence = largest_sequence(&list);
+        let list_last = *list.last().expect("bad test");
+        assert_eq!(list_last, state.current_result, "current_result");
+        assert_eq!(list.len() as u32, state.total_count, "total_count");
+        assert_eq!(max_sequence as u32, state.longest_run, "longest_run");
+        assert_eq!(list.len() as u32, state.current_id, "current_id");
+
+        // eyeballing these values
+        assert_eq!(1, state.current_run, "current_run");
+        assert_eq!(14, state.count_result_in_a_run, "count_result_in_a_run");
+    }
+
+    #[test]
     fn display() {
         let a = AppState::new(1);
         assert_eq!(
             "total rolls: 1\ntotal runs: 0 (0%)\nlongest run: 0\n",
             a.to_string()
+        );
+    }
+
+    /// Of the three correct implementations, the one that has the best readability is the following `largest_sequence`
+    /// This implementation is straightforward and easy to understand. It uses a simple loop and conditional statements to keep track of the current and maximum sequences. The variable names (`max_sequence`, `current_sequence`, `previous_item`) are descriptive and help to clarify their purpose.
+    /// The functional versions of the code, while concise, might be less readable for developers who are not familiar with functional programming concepts. They involve higher-order functions, closures, and methods like `fold`, `map`, and `unwrap_or`, which can introduce additional complexity for those who are new to these concepts.
+    /// Therefore, in terms of readability, the initial imperative implementation with explicit loop and conditionals tends to be more approachable and easier to understand for most developers.
+    /// -- Coding AI, 2023
+    fn largest_sequence(list: &[bool]) -> usize {
+        let mut max_sequence = 0;
+        let mut current_sequence = 0;
+        let mut previous_item: Option<bool> = None;
+
+        for &item in list {
+            if let Some(prev_item) = previous_item {
+                if item != prev_item {
+                    current_sequence = 0;
+                }
+                current_sequence += 1;
+            }
+            max_sequence = max_sequence.max(current_sequence);
+            previous_item = Some(item);
+        }
+
+        max_sequence
+    }
+
+    #[test]
+    fn test_largest_sequence() {
+        assert_eq!(
+            3,
+            largest_sequence(&[true, false, false, false, true, true])
+        );
+        assert_eq!(
+            4,
+            largest_sequence(&[false, true, true, true, true, false, false, false, true, false])
         );
     }
 }

--- a/src/flipper/predictors/control.rs
+++ b/src/flipper/predictors/control.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-use rand::{Rng, rngs::ThreadRng};
+use rand::{rngs::ThreadRng, Rng};
 
 use crate::flipper::{
     account::{Bet, Better},
@@ -13,6 +13,7 @@ pub struct Prediction {
     guess: bool,
 }
 
+/// guesses and bets randomly
 impl Prediction {
     pub fn new() -> Prediction {
         Prediction {
@@ -22,6 +23,7 @@ impl Prediction {
     }
 }
 
+/// guess randomly by flipping another coin (rng)
 impl Predictor for Prediction {
     fn predict(&mut self, _: &AppState) -> bool {
         self.guess = self.rng.gen_bool(0.5);
@@ -29,10 +31,9 @@ impl Predictor for Prediction {
     }
 }
 
+/// doubles the bet 50% of the time, because it's a 50% probabiliy that it's the same as last time
 impl Better for Prediction {
     fn bet(&mut self, _state: &AppState) -> Option<Bet> {
-        // about 50% of the time it will be the same roll as last time, so double down 50% of the
-        // time
         let double_down = self.rng.gen_bool(0.5);
         Some(Bet {
             wager: if double_down { 2 } else { 1 },
@@ -41,8 +42,64 @@ impl Better for Prediction {
     }
 }
 
+/// the name of the predictor is "Control"
 impl fmt::Display for Prediction {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "Control")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn predictions_and_bets() {
+        // GIVEN a predictor
+        let runs = 10000;
+        let mut p = Prediction::new();
+        let state = AppState::new(runs);
+
+        // it should predict about 50%
+        let mut true_count = 0;
+        let mut bet_on_true_count = 0;
+        let mut double_down_count = 0;
+        for _ in 0..runs {
+            if p.predict(&state) {
+                true_count += 1;
+            }
+            if let Some(b) = p.bet(&state) {
+                if b.on {
+                    bet_on_true_count += 1;
+                }
+                if b.wager == 2 {
+                    double_down_count += 1;
+                }
+            }
+        }
+
+        assert!(
+            true_count > 4900 && true_count < 5100,
+            "true_count:{} should be about 50% of {}",
+            true_count,
+            runs
+        );
+        assert!(
+            bet_on_true_count == true_count,
+            "bet_on_true_count:{} should be exactly what it guessed true_count:{}",
+            bet_on_true_count,
+            true_count
+        );
+        assert!(
+            double_down_count > 4900 && double_down_count < 5100,
+            "double_down_count:{} should be about 50% of {}",
+            double_down_count,
+            runs
+        );
+    }
+
+    #[test]
+    fn name() {
+        let p = Prediction::new();
+        assert_eq!("Control", p.to_string());
     }
 }


### PR DESCRIPTION
Added more tests to app_state to get 100% coverage
Updating cargo

# Tarpaulin reults:
running 10 tests
test flipper::app_state::tests::test_largest_sequence ... ok
test flipper::account::tests::one_hundred_percent_coverage ... ok
test flipper::account::tests::display ... ok
test flipper::app_state::tests::display ... ok
test flipper::app_state::tests::next ... ok
test flipper::app_state::tests::next_saved_context ... ok
test flipper::account::tests::bank ... ok
test flipper::account::tests::bookie ... ok
test flipper::predictors::control::tests::name ... ok
test flipper::predictors::control::tests::predictions_and_bets ... ok

test result: ok. 10 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.04s

May 12 22:38:31.813  INFO cargo_tarpaulin::report: Coverage Results:
|| Uncovered Lines:
|| src/flipper/app.rs: 14-16, 18-22, 25-26, 28-33, 35, 38, 41
|| src/flipper/csv.rs: 4-6, 8-11, 13-19, 25
|| src/flipper/io.rs: 3-4, 6-7, 9-10
|| src/flipper/predictors/flipper.rs: 14, 20-22, 27-32, 38-39
|| src/flipper/predictors/money.rs: 14, 20-22, 27-29, 31-32, 34, 40-41
|| src/flipper/predictors/opposite.rs: 12, 18-19, 24-29, 35-36
|| src/flipper/stats.rs: 12-15, 17-19, 30, 32, 34, 40-41, 46-47
|| src/main.rs: 33-34, 36-40, 43-48, 50-51
|| Tested/Total Lines:
|| src/flipper/account.rs: 22/22 +0.00%
|| src/flipper/app.rs: 0/19 +0.00%
|| src/flipper/app_state.rs: 20/20 +0.00%
|| src/flipper/csv.rs: 0/15 +0.00%
|| src/flipper/io.rs: 0/6 +0.00%
|| src/flipper/predictors/control.rs: 12/12 +0.00%
|| src/flipper/predictors/flipper.rs: 0/12 +0.00%
|| src/flipper/predictors/money.rs: 0/12 +0.00%
|| src/flipper/predictors/opposite.rs: 0/11 +0.00%
|| src/flipper/stats.rs: 0/14 +0.00%
|| src/main.rs: 0/15 +0.00%
|| 
34.18% coverage, 54/158 lines covered, +0.00% change in coverage