### PR TITLE
coverage for csv

### DIFF
--- a/src/flipper/csv.rs
+++ b/src/flipper/csv.rs
@@ -1,8 +1,12 @@
 use super::{app::app, stats::FinalStats};
 use std::{error::Error, io};
 
-pub fn multi_csv(total_count: u32, total_app: u32) -> Result<(), Box<dyn Error>> {
-    let mut csv_writer = csv::Writer::from_writer(io::stdout());
+pub fn multi_csv(
+    total_count: u32,
+    total_app: u32,
+    writer: &mut dyn io::Write,
+) -> Result<(), Box<dyn Error>> {
+    let mut csv_writer = csv::Writer::from_writer(writer);
     _ = csv_writer.write_record([&"Kind", &"accuracy", &"money"]);
 
     for _ in 0..total_app {
@@ -17,4 +21,34 @@ pub fn multi_csv(total_count: u32, total_app: u32) -> Result<(), Box<dyn Error>>
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::multi_csv;
+    use std::io::{BufRead, BufWriter};
+
+    #[test]
+    fn runs_the_app_multiple_times() {
+        // GIVEN multiple ocunts and multiple apps
+        let total_count = 2;
+        let total_app = 3;
+        let mut buffer = BufWriter::new(vec![]);
+        // WHEN multi_csv is called
+        let result = multi_csv(total_count, total_app, &mut buffer);
+
+        // THEN it should run without error
+        assert!(result.is_ok(), "multi_csv should run without error");
+
+        // AND it should write the correct number of lines
+        let number_of_predictors = 4;
+        let total_line_items = total_app * number_of_predictors;
+        let header_length = 1;
+        let total_lines = total_line_items + header_length;
+        assert_eq!(
+            total_lines,
+            buffer.into_inner().unwrap().lines().count() as u32,
+            "total number of lines in the csv"
+        );
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 mod flipper;
 
 use clap::{Parser, Subcommand};
+use std::io;
 use std::process;
 
 #[derive(Subcommand, Debug)]
@@ -35,8 +36,9 @@ fn main() {
 
     match args.command {
         Commands::Csv { count, apps } => {
-            if let Err(e) = flipper::multi_csv(count, apps) {
-                println!("Error: {}", e);
+            let mut stdout = io::stdout();
+            if let Err(e) = flipper::multi_csv(count, apps, &mut stdout) {
+                println!("CSV Error: {}", e);
                 process::exit(1);
             }
         }


### PR DESCRIPTION
running 15 tests
test flipper::account::tests::one_hundred_percent_coverage ... ok
test flipper::account::tests::display ... ok
test flipper::app_state::tests::display ... ok
test flipper::app_state::tests::next ... ok
test flipper::app_state::tests::next_saved_context ... ok
test flipper::account::tests::bookie ... ok
test flipper::app::tests::total_count_in_state ... ok
test flipper::account::tests::bank ... ok
test flipper::predictors::control::tests::predictions_and_bets ... ok
test flipper::stats::tests::running_stats::update ... ok
test flipper::app_state::tests::test_largest_sequence ... ok
test flipper::predictors::control::tests::name ... ok
test flipper::stats::tests::running_stats::accuracy ... ok
test flipper::stats::tests::final_stats::display ... ok
test flipper::csv::tests::runs_the_app_multiple_times ... ok

test result: ok. 15 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.04s

May 14 11:36:37.138  INFO cargo_tarpaulin::report: Coverage Results:
|| Uncovered Lines:
|| src/flipper/io.rs: 3-4, 6-7, 9-10
|| src/main.rs: 34-35, 37-42, 45-48
|| Tested/Total Lines:
|| src/flipper/account.rs: 22/22 +0.00%
|| src/flipper/app.rs: 19/19 +0.00%
|| src/flipper/app_state.rs: 20/20 +0.00%
|| src/flipper/csv.rs: 12/12 +100.00%
|| src/flipper/io.rs: 0/6 +0.00%
|| src/flipper/predictors/control.rs: 12/12 +0.00%
|| src/flipper/predictors/flipper.rs: 12/12 +16.67%
|| src/flipper/predictors/money.rs: 12/12 +16.67%
|| src/flipper/predictors/opposite.rs: 11/11 +18.18%
|| src/flipper/stats.rs: 14/14 +0.00%
|| src/main.rs: 0/12 +0.00%
|| 
88.16% coverage, 134/152 lines covered, +11.34% change in coverage