### PR TITLE
Refactor io/csv into RunnerLoop

### DIFF
--- a/src/flipper/csv.rs
+++ b/src/flipper/csv.rs
@@ -1,8 +1,4 @@
-use super::{
-    app_state::AppState,
-    runner::{Runner, RunnerLoop},
-    stats::FinalStats,
-};
+use super::{app_state::AppState, runner::RunnerLoop, stats::FinalStats};
 use std::{error::Error, io};
 
 pub struct Csv<'w> {
@@ -16,13 +12,9 @@ impl<'w> Csv<'w> {
         Self { writer }
     }
 
-    pub fn print(
-        &mut self,
-        runner: &Runner,
-        final_stats: &FinalStats,
-    ) -> Result<(), Box<dyn Error>> {
+    pub fn print(&mut self, name: &str, final_stats: &FinalStats) -> Result<(), Box<dyn Error>> {
         self.writer.write_record(&[
-            runner.predictor.to_string(),
+            name.to_string(),
             format!("{}", final_stats.accuracy),
             format!("{}", final_stats.money_difference),
         ])?;
@@ -35,11 +27,11 @@ impl RunnerLoop for Csv<'_> {
 
     fn each_run(
         &mut self,
+        name: &str,
         _state: &AppState,
-        runner: &Runner,
         final_stats: &FinalStats,
     ) -> Result<(), Box<dyn Error>> {
-        self.print(runner, final_stats)?;
+        self.print(name, final_stats)?;
         Ok(())
     }
 }

--- a/src/flipper/io.rs
+++ b/src/flipper/io.rs
@@ -1,13 +1,28 @@
-use super::{app_state::AppState, runner::Runner, stats::FinalStats};
+use super::{
+    app_state::AppState,
+    runner::{Runner, RunnerLoop},
+    stats::FinalStats,
+};
 
-pub fn print(state: &AppState, runners: &Vec<Runner>) {
+pub fn print(state: &AppState, runner: &Runner, final_stats: &FinalStats) {
     println!("{}", state);
+    println!("* {:10} {}", runner.predictor.to_string(), final_stats,);
+}
 
-    for runner in runners {
-        println!(
-            "* {:10} {}",
-            runner.predictor.to_string(),
-            FinalStats::new(&runner.stats, &runner.account, state.total_count,),
-        );
+pub struct IO;
+
+impl RunnerLoop for IO {
+    fn each_app(&self, state: &AppState) {
+        println!("{}", state);
+    }
+
+    fn each_run(
+        &mut self,
+        state: &AppState,
+        runner: &Runner,
+        final_stats: &FinalStats,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        print(state, runner, final_stats);
+        Ok(())
     }
 }

--- a/src/flipper/io.rs
+++ b/src/flipper/io.rs
@@ -1,12 +1,8 @@
-use super::{
-    app_state::AppState,
-    runner::{Runner, RunnerLoop},
-    stats::FinalStats,
-};
+use super::{app_state::AppState, runner::RunnerLoop, stats::FinalStats};
 
-pub fn print(state: &AppState, runner: &Runner, final_stats: &FinalStats) {
+pub fn print(name: &str, state: &AppState, final_stats: &FinalStats) {
     println!("{}", state);
-    println!("* {:10} {}", runner.predictor.to_string(), final_stats,);
+    println!("* {:10} {}", name, final_stats,);
 }
 
 pub struct IO;
@@ -18,11 +14,11 @@ impl RunnerLoop for IO {
 
     fn each_run(
         &mut self,
+        name: &str,
         state: &AppState,
-        runner: &Runner,
         final_stats: &FinalStats,
     ) -> Result<(), Box<dyn std::error::Error>> {
-        print(state, runner, final_stats);
+        print(name, state, final_stats);
         Ok(())
     }
 }

--- a/src/flipper/mod.rs
+++ b/src/flipper/mod.rs
@@ -1,14 +1,14 @@
 mod account;
 pub mod app;
-mod app_state;
+pub mod app_state;
 pub mod csv;
 pub mod io;
 mod predictor;
 #[macro_use]
-mod runner;
+pub mod runner;
 mod predictors;
-mod stats;
+pub mod stats;
 
 pub use self::app::app;
-pub use self::csv::multi_csv;
+pub use self::csv::Csv;
 pub use self::io::print;

--- a/src/flipper/predictors/control.rs
+++ b/src/flipper/predictors/control.rs
@@ -78,7 +78,7 @@ mod tests {
         }
 
         assert!(
-            true_count > 4900 && true_count < 5100,
+            true_count > 4750 && true_count < 5250, // P < 0.05 = 500/10000, so anything in that range is statistically significant
             "true_count:{} should be about 50% of {}",
             true_count,
             runs

--- a/src/flipper/runner.rs
+++ b/src/flipper/runner.rs
@@ -1,4 +1,9 @@
-use super::{account::Account, predictor::Predictor, stats::RunningStats};
+use super::{
+    account::Account,
+    app_state::AppState,
+    predictor::Predictor,
+    stats::{FinalStats, RunningStats},
+};
 pub struct Runner {
     pub predictor: Box<dyn Predictor>,
     pub stats: RunningStats,
@@ -14,4 +19,14 @@ macro_rules! runner {
             account: $crate::flipper::account::Account::new($total),
         }
     };
+}
+
+pub trait RunnerLoop {
+    fn each_app(&self, state: &AppState);
+    fn each_run(
+        &mut self,
+        state: &AppState,
+        runner: &Runner,
+        final_stats: &FinalStats,
+    ) -> Result<(), Box<dyn std::error::Error>>;
 }

--- a/src/flipper/runner.rs
+++ b/src/flipper/runner.rs
@@ -25,8 +25,8 @@ pub trait RunnerLoop {
     fn each_app(&self, state: &AppState);
     fn each_run(
         &mut self,
+        name: &str,
         state: &AppState,
-        runner: &Runner,
         final_stats: &FinalStats,
     ) -> Result<(), Box<dyn std::error::Error>>;
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -61,7 +61,7 @@ fn main() {
         for runner in runners {
             let final_stats = FinalStats::new(&runner.stats, &runner.account, state.total_count);
 
-            if let Err(e) = command.each_run(&state, &runner, &final_stats) {
+            if let Err(e) = command.each_run(&runner.predictor.to_string(), &state, &final_stats) {
                 println!("Error: {}", e);
                 process::exit(1);
             }


### PR DESCRIPTION
Refactored io and csv to both implement a new trait `RunnerLoop`
Main now runs the two app and total runs loops, and then executes the hooks in RunnerLoop for whichever one was chosen.
This moves the logic for running the two loops totally outside of io and csv, where they don't belong.

test flipper::csv::tests::prints_header ... ok
test flipper::csv::tests::prints_csv_line ... ok

May 14 20:32:08.528  INFO cargo_tarpaulin::report: Coverage Results:
|| Uncovered Lines:
|| src/flipper/io.rs: 3-5, 11-12, 15, 21-22
|| src/flipper/predictors/flipper.rs: 38-39
|| src/flipper/predictors/money.rs: 40-41
|| src/flipper/predictors/opposite.rs: 35-36
|| Tested/Total Lines:
|| src/flipper/csv.rs: 13/13 +0.00%
|| src/flipper/io.rs: 0/8 +0.00%
|| src/flipper/predictors/control.rs: 12/12 +0.00%
|| src/flipper/predictors/flipper.rs: 10/12 -16.67%
|| src/flipper/predictors/money.rs: 10/12 -16.67%
|| src/flipper/predictors/opposite.rs: 9/11 -18.18%
|| 
78.66% coverage, 129/164 lines covered, -9.50% change in coverage
(Stats fell in predictors because the test code for csv is more I/O focused.)