### PR TITLE
86% coverage - 100% for io, flipper, money, and opposite

### DIFF
--- a/src/flipper/app_state.rs
+++ b/src/flipper/app_state.rs
@@ -75,7 +75,7 @@ impl fmt::Display for AppState {
             self.count_result_in_a_run,
             self.count_result_in_a_run as f32 / self.total_count as f32
         )?;
-        writeln!(f, "longest run: {}", self.longest_run)
+        write!(f, "longest run: {}", self.longest_run)
     }
 }
 
@@ -194,7 +194,7 @@ mod tests {
     fn display() {
         let a = AppState::new(1);
         assert_eq!(
-            "total rolls: 1\ntotal runs: 0 (0%)\nlongest run: 0\n",
+            "total rolls: 1\ntotal runs: 0 (0%)\nlongest run: 0",
             a.to_string()
         );
     }

--- a/src/flipper/csv.rs
+++ b/src/flipper/csv.rs
@@ -23,8 +23,6 @@ impl<'w> Csv<'w> {
 }
 
 impl RunnerLoop for Csv<'_> {
-    fn each_app(&self, _state: &AppState) {}
-
     fn each_run(
         &mut self,
         name: &str,
@@ -67,7 +65,6 @@ mod tests {
             let mut csv = Csv::new(&mut buffer);
 
             // WHEN Csv::print is called
-            csv.each_app(&app_state);
             _ = csv.each_run(
                 "name",
                 &app_state,

--- a/src/flipper/io.rs
+++ b/src/flipper/io.rs
@@ -1,24 +1,70 @@
 use super::{app_state::AppState, runner::RunnerLoop, stats::FinalStats};
 
-pub fn print(name: &str, state: &AppState, final_stats: &FinalStats) {
-    println!("{}", state);
-    println!("* {:10} {}", name, final_stats,);
+pub struct IO<'w> {
+    writer: &'w mut dyn std::io::Write,
 }
 
-pub struct IO;
-
-impl RunnerLoop for IO {
-    fn each_app(&self, state: &AppState) {
-        println!("{}", state);
+impl<'w> IO<'w> {
+    pub fn new(writer: &'w mut dyn std::io::Write) -> Self {
+        Self { writer }
     }
+}
 
+impl RunnerLoop for IO<'_> {
     fn each_run(
         &mut self,
         name: &str,
         state: &AppState,
         final_stats: &FinalStats,
     ) -> Result<(), Box<dyn std::error::Error>> {
-        print(name, state, final_stats);
+        writeln!(self.writer, "{}", state)?;
+        writeln!(self.writer, "* {:10} {}", name, final_stats)?;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{AppState, FinalStats, RunnerLoop, IO};
+    use std::io::BufWriter;
+
+    #[test]
+    fn prints() {
+        // GIVEN a IO object
+        let mut buffer = BufWriter::new(vec![]);
+        // block for io to release buffer
+        {
+            let mut io = IO::new(&mut buffer);
+            let name = "test";
+            let state = AppState::new(100);
+            let final_stats = FinalStats {
+                money_difference: -3,
+                expected_money: 100,
+                accuracy: 0.5,
+            };
+
+            // WHEN a line is printed
+            _ = io.each_run(name, &state, &final_stats);
+        }
+
+        // THEN it should write the line
+        let string_of_buffer = bufwriter_to_string(buffer);
+        assert_eq!(
+            "total rolls: 100\n\
+             total runs: 0 (0%)\n\
+             longest run: 0\n\
+             * test       accuracy:0.5      , $       -3:        -3\n",
+            string_of_buffer,
+            "a single line of status for a predictor"
+        );
+    }
+
+    fn bufwriter_to_string(bufwriter: BufWriter<Vec<u8>>) -> String {
+        String::from_utf8(
+            bufwriter
+                .into_inner()
+                .expect("should be able to get the buffer"),
+        )
+        .expect("should be able to get the string")
     }
 }

--- a/src/flipper/mod.rs
+++ b/src/flipper/mod.rs
@@ -11,4 +11,3 @@ pub mod stats;
 
 pub use self::app::app;
 pub use self::csv::Csv;
-pub use self::io::print;

--- a/src/flipper/predictors/control.rs
+++ b/src/flipper/predictors/control.rs
@@ -90,7 +90,7 @@ mod tests {
             true_count
         );
         assert!(
-            double_down_count > 4900 && double_down_count < 5100,
+            double_down_count > 4750 && double_down_count < 5250,
             "double_down_count:{} should be about 50% of {}",
             double_down_count,
             runs

--- a/src/flipper/predictors/flipper.rs
+++ b/src/flipper/predictors/flipper.rs
@@ -45,7 +45,7 @@ mod tests {
     use super::{AppState, Better, Prediction, Predictor};
 
     #[test]
-    fn flipper_chooses_the_opposite() {
+    fn chooses_the_opposite_of_last_time() {
         // GIVEN the flipper predictor
         let mut p = Prediction::new();
         let app_state = AppState::new(0);
@@ -59,7 +59,7 @@ mod tests {
     }
 
     #[test]
-    fn flipper_bets_double_down_every_other_time() {
+    fn bets_double_down_every_other_time() {
         // GIVEN the flipper predictor
         let mut p = Prediction::new();
         let mut app_state = AppState::new(0);

--- a/src/flipper/predictors/flipper.rs
+++ b/src/flipper/predictors/flipper.rs
@@ -39,3 +39,53 @@ impl fmt::Display for Prediction {
         write!(f, "Flipper")
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{AppState, Better, Prediction, Predictor};
+
+    #[test]
+    fn flipper_chooses_the_opposite() {
+        // GIVEN the flipper predictor
+        let mut p = Prediction::new();
+        let app_state = AppState::new(0);
+
+        // WHEN predict is called
+        let first = p.predict(&app_state);
+        let second = p.predict(&app_state);
+
+        // THEN it should predict the opposite
+        assert_ne!(first, second, "first and second predictions should flip");
+    }
+
+    #[test]
+    fn flipper_bets_double_down_every_other_time() {
+        // GIVEN the flipper predictor
+        let mut p = Prediction::new();
+        let mut app_state = AppState::new(0);
+
+        // WHEN bet is called
+        let first = p.bet(&app_state).unwrap();
+        app_state = app_state.next(true);
+        let second = p.bet(&app_state).unwrap();
+        app_state = app_state.next(true);
+        let third = p.bet(&app_state).unwrap();
+        app_state = app_state.next(true);
+        let fourth = p.bet(&app_state).unwrap();
+
+        // THEN it should bet double down every other time
+        assert_eq!(first.wager, 2, "first bet should be double down");
+        assert_eq!(second.wager, 2, "second bet should be double down");
+        assert_eq!(third.wager, 1, "third bet should be single down");
+        assert_eq!(fourth.wager, 1, "fourth bet should be single down");
+    }
+
+    #[test]
+    fn name() {
+        assert_eq!(
+            "Flipper".to_string(),
+            Prediction::new().to_string(),
+            "name is Flipper"
+        );
+    }
+}

--- a/src/flipper/predictors/money.rs
+++ b/src/flipper/predictors/money.rs
@@ -41,3 +41,74 @@ impl fmt::Display for Prediction {
         write!(f, "Money")
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{AppState, Better, Prediction, Predictor};
+
+    #[test]
+    fn chooses_the_opposite() {
+        // GIVEN the money predictor
+        let mut p = Prediction::new();
+        let mut app_state = AppState::new(0);
+
+        // WHEN predict is called
+        app_state = app_state.next(true);
+        let first = p.predict(&app_state);
+
+        app_state = app_state.next(false);
+        let second = p.predict(&app_state);
+
+        // THEN it should predict the opposite
+        assert!(!first, "first should be false");
+        assert!(second, "second should be true");
+    }
+
+    #[test]
+    fn bets_double_down_every_other_time() {
+        // GIVEN the money predictor
+        let mut p = Prediction::new();
+        let mut app_state = AppState::new(0);
+
+        // WHEN bet is called
+        app_state = app_state.next(false);
+        let first = p.bet(&app_state);
+        app_state = app_state.next(false);
+        let second = p.bet(&app_state);
+        app_state = app_state.next(false);
+        let third = p.bet(&app_state);
+        app_state = app_state.next(true);
+        let fourth = p.bet(&app_state);
+
+        // THEN it should bet double down every other time
+        assert!(
+            matches!(first, None),
+            "first bet should be nothing, no prior"
+        );
+        // TODO: bet should be 2, it's the first time it's seen a run
+        assert_eq!(
+            second.expect("second should be a bet").wager,
+            4,
+            "second bet should be 4"
+        );
+        // TODO: bet should be 4
+        assert_eq!(
+            third.expect("third should be a bet").wager,
+            6,
+            "third bet should be 6"
+        );
+        assert!(
+            matches!(fourth, None),
+            "fourth bet should be nothing, no prior"
+        );
+    }
+
+    #[test]
+    fn name() {
+        assert_eq!(
+            "Money".to_string(),
+            Prediction::new().to_string(),
+            "name is Money"
+        );
+    }
+}

--- a/src/flipper/predictors/opposite.rs
+++ b/src/flipper/predictors/opposite.rs
@@ -43,7 +43,7 @@ mod tests {
 
     #[test]
     fn chooses_the_opposite() {
-        // GIVEN the flipper predictor
+        // GIVEN the opposite predictor
         let mut p = Prediction::new();
         let mut app_state = AppState::new(0);
 

--- a/src/flipper/predictors/opposite.rs
+++ b/src/flipper/predictors/opposite.rs
@@ -36,3 +36,57 @@ impl fmt::Display for Prediction {
         write!(f, "Opposite")
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{AppState, Better, Prediction, Predictor};
+
+    #[test]
+    fn chooses_the_opposite() {
+        // GIVEN the flipper predictor
+        let mut p = Prediction::new();
+        let mut app_state = AppState::new(0);
+
+        // WHEN predict is called
+        app_state = app_state.next(true);
+        let first = p.predict(&app_state);
+
+        app_state = app_state.next(false);
+        let second = p.predict(&app_state);
+
+        // THEN it should predict the opposite
+        assert!(!first, "first should be false");
+        assert!(second, "second should be true");
+    }
+
+    #[test]
+    fn bets_double_down_every_other_time() {
+        // GIVEN the opposite predictor
+        let mut p = Prediction::new();
+        let mut app_state = AppState::new(0);
+
+        // WHEN bet is called
+        let first = p.bet(&app_state).unwrap();
+        app_state = app_state.next(true);
+        let second = p.bet(&app_state).unwrap();
+        app_state = app_state.next(false);
+        let third = p.bet(&app_state).unwrap();
+        app_state = app_state.next(true);
+        let fourth = p.bet(&app_state).unwrap();
+
+        // THEN it should bet double down every other time
+        assert_eq!(first.wager, 2, "first bet should be double down");
+        assert_eq!(second.wager, 2, "second bet should be double down");
+        assert_eq!(third.wager, 1, "third bet should be single down");
+        assert_eq!(fourth.wager, 1, "fourth bet should be single down");
+    }
+
+    #[test]
+    fn name() {
+        assert_eq!(
+            "Opposite".to_string(),
+            Prediction::new().to_string(),
+            "name is Opposite"
+        );
+    }
+}

--- a/src/flipper/runner.rs
+++ b/src/flipper/runner.rs
@@ -22,7 +22,6 @@ macro_rules! runner {
 }
 
 pub trait RunnerLoop {
-    fn each_app(&self, state: &AppState);
     fn each_run(
         &mut self,
         name: &str,

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,7 +49,7 @@ fn main() {
         Commands::Stdout { count, apps } => {
             total_count = count;
             total_apps = apps;
-            let io = flipper::io::IO;
+            let io = flipper::io::IO::new(&mut stdout);
             Box::new(io)
         }
     };
@@ -57,7 +57,6 @@ fn main() {
     for _ in 0..total_apps {
         let (state, runners) = flipper::app(total_count);
 
-        command.each_app(&state);
         for runner in runners {
             let final_stats = FinalStats::new(&runner.stats, &runner.account, state.total_count);
 


### PR DESCRIPTION
running 26 tests
test flipper::account::tests::one_hundred_percent_coverage ... ok
test flipper::account::tests::display ... ok
test flipper::app_state::tests::display ... ok
test flipper::account::tests::bank ... ok
test flipper::app_state::tests::next ... ok
test flipper::app_state::tests::next_saved_context ... ok
test flipper::account::tests::bookie ... ok
test flipper::app::tests::total_count_in_state ... ok
test flipper::predictors::control::tests::predictions_and_bets ... ok
test flipper::predictors::flipper::tests::bets_double_down_every_other_time ... ok
test flipper::predictors::flipper::tests::chooses_the_opposite_of_last_time ... ok
test flipper::app_state::tests::test_largest_sequence ... ok
test flipper::predictors::control::tests::name ... ok
test flipper::csv::tests::prints_header ... ok
test flipper::io::tests::prints ... ok
test flipper::csv::tests::prints_csv_line ... ok
test flipper::predictors::opposite::tests::chooses_the_opposite ... ok
test flipper::predictors::opposite::tests::bets_double_down_every_other_time ... ok
test flipper::predictors::money::tests::chooses_the_opposite ... ok
test flipper::predictors::money::tests::bets_double_down_every_other_time ... ok
test flipper::predictors::opposite::tests::name ... ok
test flipper::predictors::money::tests::name ... ok
test flipper::stats::tests::final_stats::display ... ok
test flipper::predictors::flipper::tests::name ... ok
test flipper::stats::tests::running_stats::update ... ok
test flipper::stats::tests::running_stats::accuracy ... ok

test result: ok. 26 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.08s

May 14 22:09:04.131  INFO cargo_tarpaulin::report: Coverage Results:
|| Uncovered Lines:
|| src/main.rs: 35-36, 41-47, 49-53, 57-58, 60-61, 63-65
|| Tested/Total Lines:
|| src/flipper/account.rs: 22/22 +0.00%
|| src/flipper/app.rs: 19/19 +0.00%
|| src/flipper/app_state.rs: 20/20 +0.00%
|| src/flipper/csv.rs: 12/12 +0.00%
|| src/flipper/io.rs: 5/5 +100.00%
|| src/flipper/predictors/control.rs: 12/12 +0.00%
|| src/flipper/predictors/flipper.rs: 12/12 +16.67%
|| src/flipper/predictors/money.rs: 12/12 +16.67%
|| src/flipper/predictors/opposite.rs: 11/11 +18.18%
|| src/flipper/stats.rs: 14/14 +0.00%
|| src/main.rs: 0/21 +0.00%
|| 
86.88% coverage, 139/160 lines covered, +8.22% change in coverage